### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   build:
     name: Build Docusaurus
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/yuribreion1/yuribreion1.github.io/security/code-scanning/1](https://github.com/yuribreion1/yuribreion1.github.io/security/code-scanning/1)

Add an explicit `permissions` block to the `build` job in `.github/workflows/deployment.yml`.

Best fix here (without changing behavior) is job-scoped permissions:
- Keep existing `deploy` job permissions unchanged (`pages: write`, `id-token: write`).
- Add `permissions` under `jobs.build` with minimal required scope:
  - `contents: read`

This directly addresses the flagged job while preserving current deployment behavior and least privilege. No imports, methods, or external definitions are needed (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
